### PR TITLE
Refactor URL generation and validation to move the logic to Typescript

### DIFF
--- a/assets/js/wayfinder/buildUrl.test.ts
+++ b/assets/js/wayfinder/buildUrl.test.ts
@@ -1,0 +1,1256 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  RouteDefinitionWithParameters,
+  ParamConfig,
+  ParametersDefinition,
+} from './types'
+import { buildUrl } from './buildUrl'
+
+function createRouteDefinition(
+  url: string,
+  parameters: Record<string, Omit<ParamConfig, 'name'>>,
+): RouteDefinitionWithParameters<'get'> {
+  const parametersWithName = Object.entries(parameters).reduce(
+    (acc, [name, config]) => {
+      acc[name] = { ...config, name }
+      return acc
+    },
+    {} as ParametersDefinition,
+  )
+
+  return {
+    url,
+    method: 'get',
+    parameters: parametersWithName,
+  }
+}
+
+function required(): Omit<ParamConfig, 'name'> {
+  return { required: true, optional: false, glob: false }
+}
+
+function optional(): Omit<ParamConfig, 'name'> {
+  return { required: false, optional: true, glob: false }
+}
+
+function glob(): Omit<ParamConfig, 'name'> {
+  return { required: true, optional: false, glob: true }
+}
+
+function optionalGlob(): Omit<ParamConfig, 'name'> {
+  return { required: false, optional: true, glob: true }
+}
+
+describe('buildUrl', () => {
+  describe('routes with no parameters', () => {
+    const definition = createRouteDefinition('/posts', {})
+
+    it('builds URL without arguments', () => {
+      expect(buildUrl({ definition })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with null arguments', () => {
+      expect(buildUrl({ definition, args: null })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with undefined arguments', () => {
+      expect(buildUrl({ definition, args: undefined })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with empty string arguments', () => {
+      expect(buildUrl({ definition, args: '' })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('ignores invalid arguments when no parameters exist', () => {
+      expect(buildUrl({ definition, args: { invalid: 'value' } })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('handles query options', () => {
+      expect(
+        buildUrl({
+          definition,
+          options: { query: { page: 1 } },
+        }),
+      ).toEqual({
+        path: '/posts?page=1',
+        isCurrent: false,
+      })
+    })
+
+    it('removes trailing slashes except for root', () => {
+      const rootDefinition = createRouteDefinition('/', {})
+      expect(
+        buildUrl({
+          definition: rootDefinition,
+          options: { currentPath: '/other' },
+        }),
+      ).toEqual({
+        path: '/',
+        isCurrent: false,
+      })
+
+      const trailingSlashDefinition = createRouteDefinition('/posts/', {})
+      expect(
+        buildUrl({
+          definition: trailingSlashDefinition,
+          options: { currentPath: '/other' },
+        }),
+      ).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+  })
+
+  describe('routes with single required parameter', () => {
+    const definition = createRouteDefinition('/posts/:id', {
+      id: required(),
+    })
+
+    describe('valid arguments', () => {
+      it('accepts string argument', () => {
+        expect(
+          buildUrl({
+            definition,
+            args: 'test-id',
+            options: { currentPath: '/posts/test-id' },
+          }),
+        ).toEqual({
+          path: '/posts/test-id',
+          isCurrent: true,
+        })
+      })
+
+      it('accepts number argument', () => {
+        expect(buildUrl({ definition, args: 123 })).toEqual({
+          path: '/posts/123',
+          isCurrent: false,
+        })
+      })
+
+      it('accepts object argument', () => {
+        expect(buildUrl({ definition, args: { id: 'test-id' } })).toEqual({
+          path: '/posts/test-id',
+          isCurrent: false,
+        })
+      })
+
+      it('accepts array argument (uses first element)', () => {
+        expect(buildUrl({ definition, args: ['test-id', 'ignored'] })).toEqual({
+          path: '/posts/test-id',
+          isCurrent: false,
+        })
+      })
+
+      it('converts number in object to string', () => {
+        expect(buildUrl({ definition, args: { id: 456 } })).toEqual({
+          path: '/posts/456',
+          isCurrent: false,
+        })
+      })
+
+      it('converts number in array to string', () => {
+        expect(buildUrl({ definition, args: [789] })).toEqual({
+          path: '/posts/789',
+          isCurrent: false,
+        })
+      })
+
+      it('ignores extra properties in object', () => {
+        expect(
+          buildUrl({ definition, args: { id: 'test', extra: 'ignored' } }),
+        ).toEqual({
+          path: '/posts/test',
+          isCurrent: false,
+        })
+      })
+    })
+
+    describe('missing arguments', () => {
+      it('throws error when no arguments provided', () => {
+        expect(() => buildUrl({ definition })).toThrow(
+          'Missing required parameter: id',
+        )
+      })
+
+      it('throws error when null arguments provided', () => {
+        expect(() => buildUrl({ definition, args: null })).toThrow(
+          'Missing required parameter: id',
+        )
+      })
+
+      it('throws error when undefined arguments provided', () => {
+        expect(() => buildUrl({ definition, args: undefined })).toThrow(
+          'Missing required parameter: id',
+        )
+      })
+
+      it('throws error when empty string provided', () => {
+        expect(() => buildUrl({ definition, args: '' })).toThrow(
+          'Missing required parameter: id',
+        )
+      })
+
+      it('throws error when empty array provided', () => {
+        expect(() => buildUrl({ definition, args: [] })).toThrow(
+          'Missing required parameter: id',
+        )
+      })
+
+      it('throws error when parameter missing from object', () => {
+        expect(() =>
+          buildUrl({ definition, args: { other: 'value' } }),
+        ).toThrow('Missing required parameter: id')
+      })
+
+      it('throws error when parameter is null in object', () => {
+        // @ts-expect-error - Runtime case
+        expect(() => buildUrl({ definition, args: { id: null } })).toThrow(
+          'Missing required parameter: id',
+        )
+      })
+
+      it('throws error when parameter is undefined in object', () => {
+        // @ts-expect-error - Runtime case
+        expect(() => buildUrl({ definition, args: { id: undefined } })).toThrow(
+          'Missing required parameter: id',
+        )
+      })
+    })
+  })
+
+  describe('routes with single optional parameter', () => {
+    const definition = createRouteDefinition('/posts/:id', {
+      id: optional(),
+    })
+
+    it('builds URL without arguments (removes optional parameter)', () => {
+      expect(buildUrl({ definition })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with null arguments (removes optional parameter)', () => {
+      expect(buildUrl({ definition, args: null })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with undefined arguments (removes optional parameter)', () => {
+      expect(buildUrl({ definition, args: undefined })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with empty string (removes optional parameter)', () => {
+      expect(buildUrl({ definition, args: '' })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with valid string argument', () => {
+      expect(buildUrl({ definition, args: 'test-id' })).toEqual({
+        path: '/posts/test-id',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with valid number argument', () => {
+      expect(buildUrl({ definition, args: 123 })).toEqual({
+        path: '/posts/123',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with valid object argument', () => {
+      expect(buildUrl({ definition, args: { id: 'test-id' } })).toEqual({
+        path: '/posts/test-id',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with valid array argument', () => {
+      expect(buildUrl({ definition, args: ['test-id'] })).toEqual({
+        path: '/posts/test-id',
+        isCurrent: false,
+      })
+    })
+
+    it('removes parameter when not provided in object', () => {
+      expect(buildUrl({ definition, args: { other: 'value' } })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('removes parameter when null in object', () => {
+      // @ts-expect-error - Runtime case
+      expect(buildUrl({ definition, args: { id: null } })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('removes parameter when undefined in object', () => {
+      // @ts-expect-error - Runtime case
+      expect(buildUrl({ definition, args: { id: undefined } })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('removes parameter when empty array provided', () => {
+      expect(buildUrl({ definition, args: [] })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+  })
+
+  describe('routes with multiple required parameters', () => {
+    const definition = createRouteDefinition(
+      '/posts/:postId/comments/:commentId',
+      {
+        postId: required(),
+        commentId: required(),
+      },
+    )
+
+    it('accepts object with all parameters', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: { postId: 'post-1', commentId: 'comment-1' },
+        }),
+      ).toEqual({
+        path: '/posts/post-1/comments/comment-1',
+        isCurrent: false,
+      })
+    })
+
+    it('accepts array with all parameters in order', () => {
+      expect(buildUrl({ definition, args: ['post-1', 'comment-1'] })).toEqual({
+        path: '/posts/post-1/comments/comment-1',
+        isCurrent: false,
+      })
+    })
+
+    it('converts numbers to strings', () => {
+      expect(buildUrl({ definition, args: [123, 456] })).toEqual({
+        path: '/posts/123/comments/456',
+        isCurrent: false,
+      })
+
+      expect(
+        buildUrl({
+          definition,
+          args: { postId: 789, commentId: 101112 },
+        }),
+      ).toEqual({
+        path: '/posts/789/comments/101112',
+        isCurrent: false,
+      })
+    })
+
+    describe('missing parameters', () => {
+      it('throws error when no arguments provided', () => {
+        expect(() => buildUrl({ definition })).toThrow(
+          'Missing required parameters: postId, commentId',
+        )
+      })
+
+      it('throws error when some parameters missing from object', () => {
+        expect(() =>
+          buildUrl({ definition, args: { postId: 'test' } }),
+        ).toThrow('Missing required parameters: commentId')
+      })
+
+      it('throws error when array is too short', () => {
+        expect(() => buildUrl({ definition, args: ['post-1'] })).toThrow(
+          'Missing required parameters: commentId',
+        )
+      })
+
+      it('throws error when parameters are null in object', () => {
+        expect(() =>
+          buildUrl({
+            definition,
+            // @ts-expect-error - Runtime case
+            args: { postId: 'test', commentId: null },
+          }),
+        ).toThrow('Missing required parameters: commentId')
+      })
+    })
+  })
+
+  describe('routes with multiple optional parameters', () => {
+    const definition = createRouteDefinition('/posts/:one/:two/:three', {
+      one: optional(),
+      two: optional(),
+      three: optional(),
+    })
+
+    it('builds URL without arguments (removes all optional parameters)', () => {
+      expect(buildUrl({ definition })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with first parameter only', () => {
+      expect(buildUrl({ definition, args: { one: 'value1' } })).toEqual({
+        path: '/posts/value1',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with first two parameters', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: { one: 'value1', two: 'value2' },
+        }),
+      ).toEqual({
+        path: '/posts/value1/value2',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with all parameters', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: { one: 'value1', two: 'value2', three: 'value3' },
+        }),
+      ).toEqual({
+        path: '/posts/value1/value2/value3',
+        isCurrent: false,
+      })
+    })
+
+    it('accepts array arguments in order', () => {
+      expect(buildUrl({ definition, args: ['value1'] })).toEqual({
+        path: '/posts/value1',
+        isCurrent: false,
+      })
+
+      expect(buildUrl({ definition, args: ['value1', 'value2'] })).toEqual({
+        path: '/posts/value1/value2',
+        isCurrent: false,
+      })
+
+      expect(
+        buildUrl({ definition, args: ['value1', 'value2', 'value3'] }),
+      ).toEqual({
+        path: '/posts/value1/value2/value3',
+        isCurrent: false,
+      })
+    })
+
+    describe('validation of optional parameter order', () => {
+      it('throws error when skipping optional parameters (missing first)', () => {
+        expect(() => buildUrl({ definition, args: { two: 'value2' } })).toThrow(
+          'Unexpected optional parameters missing. Unable to generate a URL.',
+        )
+      })
+
+      it('throws error when skipping optional parameters (missing middle)', () => {
+        expect(() =>
+          buildUrl({
+            definition,
+            args: { one: 'value1', three: 'value3' },
+          }),
+        ).toThrow(
+          'Unexpected optional parameters missing. Unable to generate a URL.',
+        )
+      })
+
+      it('throws error when providing only last parameter', () => {
+        expect(() =>
+          buildUrl({ definition, args: { three: 'value3' } }),
+        ).toThrow(
+          'Unexpected optional parameters missing. Unable to generate a URL.',
+        )
+      })
+    })
+  })
+
+  describe('routes with mixed required and optional parameters', () => {
+    const definition = createRouteDefinition(
+      '/posts/:postId/comments/:commentId/:optional',
+      {
+        postId: required(),
+        commentId: required(),
+        optional: optional(),
+      },
+    )
+
+    it('builds URL with only required parameters', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: { postId: 'post-1', commentId: 'comment-1' },
+        }),
+      ).toEqual({
+        path: '/posts/post-1/comments/comment-1',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with all parameters', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: {
+            postId: 'post-1',
+            commentId: 'comment-1',
+            optional: 'extra',
+          },
+        }),
+      ).toEqual({
+        path: '/posts/post-1/comments/comment-1/extra',
+        isCurrent: false,
+      })
+    })
+
+    it('accepts array arguments', () => {
+      expect(buildUrl({ definition, args: ['post-1', 'comment-1'] })).toEqual({
+        path: '/posts/post-1/comments/comment-1',
+        isCurrent: false,
+      })
+
+      expect(
+        buildUrl({ definition, args: ['post-1', 'comment-1', 'extra'] }),
+      ).toEqual({
+        path: '/posts/post-1/comments/comment-1/extra',
+        isCurrent: false,
+      })
+    })
+
+    it('throws error when required parameters are missing', () => {
+      expect(() =>
+        buildUrl({ definition, args: { optional: 'value' } }),
+      ).toThrow('Missing required parameters: postId, commentId')
+    })
+
+    it('throws error when some required parameters are missing', () => {
+      expect(() =>
+        buildUrl({
+          definition,
+          args: { postId: 'test', optional: 'value' },
+        }),
+      ).toThrow('Missing required parameters: commentId')
+    })
+  })
+
+  describe('routes with required glob parameters', () => {
+    const definition = createRouteDefinition('/files/*path', {
+      path: glob(),
+    })
+
+    it('builds URL with array argument for glob', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: { path: ['folder1', 'folder2', 'file.txt'] },
+        }),
+      ).toEqual({
+        path: '/files/folder1/folder2/file.txt',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with string array as direct argument', () => {
+      expect(
+        buildUrl({ definition, args: [['folder1', 'folder2', 'file.txt']] }),
+      ).toEqual({
+        path: '/files/folder1/folder2/file.txt',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with empty array (removes glob path)', () => {
+      expect(buildUrl({ definition, args: { path: [] } })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with single item array', () => {
+      expect(buildUrl({ definition, args: { path: ['file.txt'] } })).toEqual({
+        path: '/files/file.txt',
+        isCurrent: false,
+      })
+    })
+
+    it('throws error when required glob parameter is missing', () => {
+      expect(() => buildUrl({ definition })).toThrow(
+        'Missing required parameter: path',
+      )
+    })
+
+    it('throws error when glob parameter is null', () => {
+      // @ts-expect-error - Runtime case
+      expect(() => buildUrl({ definition, args: { path: null } })).toThrow(
+        'Missing required parameter: path',
+      )
+    })
+
+    it('handles non-array values for glob (treats as empty)', () => {
+      expect(buildUrl({ definition, args: { path: 'not-array' } })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+  })
+
+  describe('routes with optional glob parameters', () => {
+    const definition = createRouteDefinition('/files/*path', {
+      path: optionalGlob(),
+    })
+
+    it('builds URL without arguments (removes optional glob)', () => {
+      expect(buildUrl({ definition })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with null arguments (removes optional glob)', () => {
+      expect(buildUrl({ definition, args: null })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with undefined arguments (removes optional glob)', () => {
+      expect(buildUrl({ definition, args: undefined })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with empty string arguments (removes optional glob)', () => {
+      expect(buildUrl({ definition, args: '' })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with array argument for optional glob', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: { path: ['folder1', 'folder2', 'file.txt'] },
+        }),
+      ).toEqual({
+        path: '/files/folder1/folder2/file.txt',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with empty array', () => {
+      expect(buildUrl({ definition, args: { path: [] } })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL when parameter is missing from object', () => {
+      expect(buildUrl({ definition, args: { other: 'value' } })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL when glob parameter is null in object', () => {
+      // @ts-expect-error - Runtime case
+      expect(buildUrl({ definition, args: { path: null } })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL when glob parameter is undefined in object', () => {
+      // @ts-expect-error - Runtime case
+      expect(buildUrl({ definition, args: { path: undefined } })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with single item in glob array', () => {
+      expect(buildUrl({ definition, args: { path: ['file.txt'] } })).toEqual({
+        path: '/files/file.txt',
+        isCurrent: false,
+      })
+    })
+
+    it('handles non-array values for optional glob (treats as empty)', () => {
+      expect(buildUrl({ definition, args: { path: 'not-array' } })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+
+    it('handles single parameter with direct array argument', () => {
+      expect(buildUrl({ definition, args: [['folder', 'file.txt']] })).toEqual({
+        path: '/files/folder/file.txt',
+        isCurrent: false,
+      })
+    })
+
+    it('handles single parameter with empty array as direct argument', () => {
+      expect(buildUrl({ definition, args: [[]] })).toEqual({
+        path: '/files',
+        isCurrent: false,
+      })
+    })
+  })
+
+  describe('routes with mixed parameters including glob', () => {
+    const definition = createRouteDefinition('/users/:userId/files/*path', {
+      userId: required(),
+      path: glob(),
+    })
+
+    it('builds URL with all parameters', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: {
+            userId: 'user-123',
+            path: ['documents', 'important', 'file.pdf'],
+          },
+        }),
+      ).toEqual({
+        path: '/users/user-123/files/documents/important/file.pdf',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with array arguments', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: ['user-123', ['documents', 'file.pdf']],
+        }),
+      ).toEqual({
+        path: '/users/user-123/files/documents/file.pdf',
+        isCurrent: false,
+      })
+    })
+
+    it('builds URL with empty glob array', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: { userId: 'user-123', path: [] },
+        }),
+      ).toEqual({
+        path: '/users/user-123/files',
+        isCurrent: false,
+      })
+    })
+
+    it('throws error when required parameter is missing', () => {
+      expect(() =>
+        buildUrl({
+          definition,
+          args: { path: ['file.txt'] },
+        }),
+      ).toThrow('Missing required parameters: userId')
+    })
+
+    it('throws error when glob parameter is missing', () => {
+      expect(() =>
+        buildUrl({
+          definition,
+          args: { userId: 'user-123' },
+        }),
+      ).toThrow('Missing required parameters: path')
+    })
+  })
+
+  describe('realistic optional glob scenarios', () => {
+    // This represents a scenario where there are multiple routes:
+    // GET /docs -> DocsController.index
+    // GET /docs/*path -> DocsController.index
+    // This would make the glob parameter optional
+    const optionalGlobDefinition = createRouteDefinition('/docs/*path', {
+      path: optionalGlob(),
+    })
+
+    it('handles documentation browsing without path (root docs)', () => {
+      expect(buildUrl({ definition: optionalGlobDefinition })).toEqual({
+        path: '/docs',
+        isCurrent: false,
+      })
+    })
+
+    it('handles documentation browsing with nested path', () => {
+      expect(
+        buildUrl({
+          definition: optionalGlobDefinition,
+          args: { path: ['api', 'users', 'create'] },
+        }),
+      ).toEqual({
+        path: '/docs/api/users/create',
+        isCurrent: false,
+      })
+    })
+
+    it('handles single-level documentation path', () => {
+      expect(
+        buildUrl({
+          definition: optionalGlobDefinition,
+          args: { path: ['getting-started'] },
+        }),
+      ).toEqual({
+        path: '/docs/getting-started',
+        isCurrent: false,
+      })
+    })
+
+    // Another realistic scenario: file serving with optional path
+    const fileServingDefinition = createRouteDefinition('/assets/*file', {
+      file: optionalGlob(),
+    })
+
+    it('serves root assets directory', () => {
+      expect(buildUrl({ definition: fileServingDefinition })).toEqual({
+        path: '/assets',
+        isCurrent: false,
+      })
+    })
+
+    it('serves nested asset files', () => {
+      expect(
+        buildUrl({
+          definition: fileServingDefinition,
+          args: { file: ['css', 'app.css'] },
+        }),
+      ).toEqual({
+        path: '/assets/css/app.css',
+        isCurrent: false,
+      })
+    })
+
+    it('serves single asset file', () => {
+      expect(
+        buildUrl({
+          definition: fileServingDefinition,
+          args: { file: ['app.js'] },
+        }),
+      ).toEqual({
+        path: '/assets/app.js',
+        isCurrent: false,
+      })
+    })
+  })
+
+  describe('query options', () => {
+    const definition = createRouteDefinition('/posts/:id', {
+      id: required(),
+    })
+
+    it('adds query parameters', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: { id: 'test' },
+          options: { query: { page: 1, limit: 10 } },
+        }),
+      ).toEqual({
+        path: '/posts/test?page=1&limit=10',
+        isCurrent: false,
+      })
+    })
+
+    it('handles currentPath for isCurrent', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: { id: 'test' },
+          options: { currentPath: '/posts/test' },
+        }),
+      ).toEqual({
+        path: '/posts/test',
+        isCurrent: true,
+      })
+    })
+
+    it('handles exactMatch option', () => {
+      expect(
+        buildUrl({
+          definition,
+          args: { id: 'test' },
+          options: {
+            currentPath: '/posts/test/comments',
+            exactMatch: true,
+          },
+        }),
+      ).toEqual({
+        path: '/posts/test',
+        isCurrent: false,
+      })
+
+      expect(
+        buildUrl({
+          definition,
+          args: { id: 'test' },
+          options: {
+            currentPath: '/posts/test/comments',
+            exactMatch: false,
+          },
+        }),
+      ).toEqual({
+        path: '/posts/test',
+        isCurrent: true,
+      })
+    })
+
+    it('works with routes without parameters', () => {
+      const noParamDef = createRouteDefinition('/posts', {})
+      expect(
+        buildUrl({
+          definition: noParamDef,
+          options: { query: { search: 'test' } },
+        }),
+      ).toEqual({
+        path: '/posts?search=test',
+        isCurrent: false,
+      })
+    })
+  })
+
+  describe('edge cases and error handling', () => {
+    it('handles empty parameter object gracefully', () => {
+      const definition = createRouteDefinition('/posts', {})
+      expect(buildUrl({ definition, args: {} })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('throws descriptive error for multiple missing required parameters', () => {
+      const definition = createRouteDefinition(
+        '/posts/:postId/comments/:commentId/replies/:replyId',
+        {
+          postId: required(),
+          commentId: required(),
+          replyId: required(),
+        },
+      )
+
+      expect(() => buildUrl({ definition, args: {} })).toThrow(
+        'Missing required parameters: postId, commentId, replyId',
+      )
+
+      expect(() => buildUrl({ definition, args: { postId: 'test' } })).toThrow(
+        'Missing required parameters: commentId, replyId',
+      )
+    })
+
+    it('filters out invalid parameter names in object args', () => {
+      const definition = createRouteDefinition('/posts/:id', {
+        id: required(),
+      })
+
+      expect(
+        buildUrl({
+          definition,
+          args: {
+            id: 'valid',
+            invalidParam: 'should-be-ignored',
+            anotherInvalid: 123,
+          },
+        }),
+      ).toEqual({
+        path: '/posts/valid',
+        isCurrent: false,
+      })
+    })
+
+    it('handles array arguments longer than parameter list', () => {
+      const definition = createRouteDefinition('/posts/:id', {
+        id: required(),
+      })
+
+      expect(
+        buildUrl({ definition, args: ['valid', 'extra', 'ignored'] }),
+      ).toEqual({
+        path: '/posts/valid',
+        isCurrent: false,
+      })
+    })
+
+    it('handles mixed type values in arrays', () => {
+      const definition = createRouteDefinition(
+        '/posts/:postId/comments/:commentId',
+        {
+          postId: required(),
+          commentId: required(),
+        },
+      )
+
+      expect(buildUrl({ definition, args: ['string-id', 123] })).toEqual({
+        path: '/posts/string-id/comments/123',
+        isCurrent: false,
+      })
+    })
+
+    it('handles complex realistic parameter scenarios', () => {
+      const definition1 = createRouteDefinition('/pages/:page/*rest', {
+        page: required(),
+        rest: glob(),
+      })
+
+      expect(
+        buildUrl({
+          definition: definition1,
+          args: {
+            page: 'home',
+            rest: ['section1', 'section2'],
+          },
+        }),
+      ).toEqual({
+        path: '/pages/home/section1/section2',
+        isCurrent: false,
+      })
+
+      expect(
+        buildUrl({
+          definition: definition1,
+          args: {
+            page: 'home',
+            rest: [],
+          },
+        }),
+      ).toEqual({
+        path: '/pages/home',
+        isCurrent: false,
+      })
+
+      const definition2 = createRouteDefinition(
+        '/posts/:postId/comments/:commentId',
+        {
+          postId: required(),
+          commentId: required(),
+        },
+      )
+
+      expect(
+        buildUrl({
+          definition: definition2,
+          args: {
+            postId: 'post-1',
+            commentId: 'comment-1',
+          },
+        }),
+      ).toEqual({
+        path: '/posts/post-1/comments/comment-1',
+        isCurrent: false,
+      })
+
+      expect(() =>
+        buildUrl({
+          definition: definition1,
+          args: { rest: ['section1'] }, // missing page
+        }),
+      ).toThrow('Missing required parameters: page')
+
+      expect(() =>
+        buildUrl({
+          definition: definition1,
+          args: { page: 'home' }, // missing rest (glob)
+        }),
+      ).toThrow('Missing required parameters: rest')
+    })
+  })
+
+  describe('parameter type coercion', () => {
+    const definition = createRouteDefinition('/posts/:id', {
+      id: required(),
+    })
+
+    it('converts number to string in object', () => {
+      expect(buildUrl({ definition, args: { id: 0 } })).toEqual({
+        path: '/posts/0',
+        isCurrent: false,
+      })
+
+      expect(buildUrl({ definition, args: { id: -123 } })).toEqual({
+        path: '/posts/-123',
+        isCurrent: false,
+      })
+
+      expect(buildUrl({ definition, args: { id: 1.5 } })).toEqual({
+        path: '/posts/1.5',
+        isCurrent: false,
+      })
+    })
+
+    it('converts number to string as direct argument', () => {
+      expect(buildUrl({ definition, args: 0 })).toEqual({
+        path: '/posts/0',
+        isCurrent: false,
+      })
+
+      expect(buildUrl({ definition, args: -456 })).toEqual({
+        path: '/posts/-456',
+        isCurrent: false,
+      })
+    })
+
+    it('handles special number values', () => {
+      expect(
+        buildUrl({ definition, args: { id: Number.MAX_SAFE_INTEGER } }),
+      ).toEqual({
+        path: '/posts/9007199254740991',
+        isCurrent: false,
+      })
+    })
+  })
+
+  describe('single parameter special cases', () => {
+    describe('single required parameter', () => {
+      const definition = createRouteDefinition('/posts/:id', {
+        id: required(),
+      })
+
+      it('throws specific error for single missing required parameter', () => {
+        expect(() => buildUrl({ definition, args: null })).toThrow(
+          'Missing required parameter: id',
+        )
+        expect(() => buildUrl({ definition, args: undefined })).toThrow(
+          'Missing required parameter: id',
+        )
+      })
+    })
+
+    describe('single optional parameter', () => {
+      const definition = createRouteDefinition('/posts/:id', {
+        id: optional(),
+      })
+
+      it('removes optional parameter when null or undefined', () => {
+        expect(buildUrl({ definition, args: null })).toEqual({
+          path: '/posts',
+          isCurrent: false,
+        })
+
+        expect(buildUrl({ definition, args: undefined })).toEqual({
+          path: '/posts',
+          isCurrent: false,
+        })
+      })
+
+      it('handles single parameter with various argument types', () => {
+        expect(buildUrl({ definition, args: 'test' })).toEqual({
+          path: '/posts/test',
+          isCurrent: false,
+        })
+
+        expect(buildUrl({ definition, args: 123 })).toEqual({
+          path: '/posts/123',
+          isCurrent: false,
+        })
+
+        expect(buildUrl({ definition, args: ['test'] })).toEqual({
+          path: '/posts/test',
+          isCurrent: false,
+        })
+
+        expect(buildUrl({ definition, args: [] })).toEqual({
+          path: '/posts',
+          isCurrent: false,
+        })
+      })
+    })
+  })
+
+  describe('all optional parameters edge case', () => {
+    const definition = createRouteDefinition('/posts/:cat/:subcat/:item', {
+      cat: optional(),
+      subcat: optional(),
+      item: optional(),
+    })
+
+    it('removes all optional parameters when args are undefined', () => {
+      expect(buildUrl({ definition, args: undefined })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+
+      expect(buildUrl({ definition, args: null })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+
+      expect(buildUrl({ definition, args: '' })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+
+    it('correctly processes parameters in reverse order for removal', () => {
+      // This tests the reverse() logic in whenAllOptional
+      expect(buildUrl({ definition })).toEqual({
+        path: '/posts',
+        isCurrent: false,
+      })
+    })
+  })
+
+  describe('string argument edge cases', () => {
+    const definition = createRouteDefinition('/posts/:id', {
+      id: required(),
+    })
+
+    it('handles empty string (treated as missing for required)', () => {
+      expect(() => buildUrl({ definition, args: '' })).toThrow(
+        'Missing required parameter: id',
+      )
+    })
+
+    it('handles whitespace-only strings', () => {
+      expect(buildUrl({ definition, args: '   ' })).toEqual({
+        path: '/posts/   ',
+        isCurrent: false,
+      })
+    })
+
+    it('handles special characters in strings', () => {
+      expect(buildUrl({ definition, args: 'test-with-dashes' })).toEqual({
+        path: '/posts/test-with-dashes',
+        isCurrent: false,
+      })
+
+      expect(buildUrl({ definition, args: 'test_with_underscores' })).toEqual({
+        path: '/posts/test_with_underscores',
+        isCurrent: false,
+      })
+    })
+  })
+})

--- a/assets/js/wayfinder/buildUrl.ts
+++ b/assets/js/wayfinder/buildUrl.ts
@@ -1,0 +1,162 @@
+import type {
+  Method,
+  ParamConfig,
+  RouteDefinitionWithParameters,
+  RouteQueryOptions,
+  WayfinderUrl,
+} from './types'
+import { queryParams, isCurrentUrl } from './index'
+
+type ObjectParameters = Record<string, string | number | (string | number)[]>
+type NonNullArgs =
+  | string
+  | number
+  | Array<string | number | Array<string | number>>
+  | ObjectParameters
+type RawArgs = NonNullArgs | null
+
+type ValidationResult = { valid: true } | { valid: false; error: string }
+
+function parseArgs({
+  args,
+  parameters,
+}: {
+  args?: RawArgs
+  parameters: ParamConfig[]
+}): ObjectParameters {
+  const isEmpty = args === undefined || args === null || args === ''
+  if (isEmpty) return {}
+
+  if (typeof args === 'string' || typeof args === 'number') {
+    if (parameters.length === 0) return {}
+    return { [parameters[0].name]: args }
+  }
+
+  if (Array.isArray(args)) {
+    return parameters.reduce((result, param, index) => {
+      if (index < args.length && args[index] !== null) {
+        result[param.name] = args[index]
+      }
+      return result
+    }, {} as ObjectParameters)
+  }
+
+  if (typeof args === 'object') {
+    return parameters.reduce((result, param) => {
+      if (args[param.name] !== null) {
+        result[param.name] = args[param.name]
+      }
+      return result
+    }, {} as ObjectParameters)
+  }
+
+  return {}
+}
+
+function validateArgs({
+  parsedArgs,
+  parameters,
+}: {
+  parsedArgs: ObjectParameters
+  parameters: ParamConfig[]
+}): ValidationResult {
+  const requiredParams = parameters.filter((p) => p.required)
+  const optionalParams = parameters.filter((p) => p.optional) // Check required parameters
+  if (requiredParams.length > 0) {
+    const missing = requiredParams
+      .filter((param) => parsedArgs[param.name] == null)
+      .map((p) => p.name)
+
+    if (missing.length > 0) {
+      const paramWord = parameters.length === 1 ? 'parameter' : 'parameters'
+      const errorMessage = `Missing required ${paramWord}: ${missing.join(', ')}`
+      return { valid: false, error: errorMessage }
+    }
+  }
+
+  if (optionalParams.length > 0) {
+    const optionalNames = optionalParams.map((p) => p.name)
+    const missing = optionalNames.filter((key) => parsedArgs[key] == null)
+
+    if (missing.length > 0 && missing.length < optionalNames.length) {
+      // Some optional params are provided, check if they're consecutive
+      const expectedMissing = optionalNames.slice(missing.length * -1)
+
+      for (let i = 0; i < missing.length; i++) {
+        if (missing[i] !== expectedMissing[i]) {
+          return {
+            valid: false,
+            error:
+              'Unexpected optional parameters missing. Unable to generate a URL.',
+          }
+        }
+      }
+    }
+  }
+
+  return { valid: true }
+}
+
+function generateUrl({
+  routePath,
+  parameters,
+  parsedArgs,
+  options,
+}: {
+  routePath: string
+  parameters: ParamConfig[]
+  parsedArgs: ObjectParameters
+  options: RouteQueryOptions
+}): WayfinderUrl {
+  const reversedParameters = [...parameters].reverse()
+
+  const url = reversedParameters.reduce((currentUrl, param) => {
+    const value = parsedArgs[param.name]
+
+    if (param.glob) {
+      // For glob parameters: if value is an array, join with slashes; otherwise remove the glob
+      const replacement = Array.isArray(value) ? `/${value.join('/')}` : ''
+      return currentUrl.replace(`/*${param.name}`, replacement)
+    } else {
+      if (value !== null && value !== undefined) {
+        return currentUrl.replace(`:${param.name}`, value.toString())
+      } else {
+        return currentUrl.replace(new RegExp(`\\/:${param.name}(?=\\/|$)`), '')
+      }
+    }
+  }, routePath)
+
+  const cleanPath = url.replace(/\/+$/, '') || '/'
+  const finalPath = cleanPath + queryParams(options)
+
+  return {
+    path: finalPath,
+    isCurrent: isCurrentUrl({
+      routePath: url,
+      currentPath: options?.currentPath,
+      exactMatch: options?.exactMatch,
+    }),
+  }
+}
+
+export function buildUrl<M extends Method | Method[]>({
+  definition,
+  args,
+  options = {},
+}: {
+  definition: RouteDefinitionWithParameters<M>
+  args?: RawArgs
+  options?: RouteQueryOptions
+}): WayfinderUrl {
+  const routePath = definition.url
+  const parameters = Object.values(definition.parameters)
+  const parsedArgs = parseArgs({ args, parameters })
+
+  const validation = validateArgs({ parsedArgs, parameters })
+
+  if (!validation.valid) {
+    throw new Error(validation.error)
+  }
+
+  return generateUrl({ routePath, parameters, parsedArgs, options })
+}

--- a/assets/js/wayfinder/index.test.ts
+++ b/assets/js/wayfinder/index.test.ts
@@ -68,10 +68,7 @@ describe('queryParams', () => {
         },
       })
 
-      expectQuery(
-        result,
-        '?existing=1&foo[]=x&foo[]=y&bar=z',
-      )
+      expectQuery(result, '?existing=1&foo[]=x&foo[]=y&bar=z')
     })
 
     it('handles nested object params', () => {
@@ -110,10 +107,7 @@ describe('queryParams', () => {
         },
       })
 
-      expectQuery(
-        result,
-        '?existing=1&foo[]=a&nested[one]=1&nested[two]=2',
-      )
+      expectQuery(result, '?existing=1&foo[]=a&nested[one]=1&nested[two]=2')
     })
   })
 

--- a/assets/js/wayfinder/index.ts
+++ b/assets/js/wayfinder/index.ts
@@ -66,22 +66,6 @@ export const queryParams = (options?: RouteQueryOptions): string => {
   return str.length > 0 ? `?${str}` : ''
 }
 
-// TODO: Add tests for this
-export const validateParameters = (
-  args: Record<string, unknown> | undefined,
-  optional: string[],
-) => {
-  const missing = optional.filter((key) => !args?.[key])
-  const expectedMissing = optional.slice(missing.length * -1)
-
-  for (let i = 0; i < missing.length; i++) {
-    if (missing[i] !== expectedMissing[i]) {
-      throw Error(
-        'Unexpected optional parameters missing. Unable to generate a URL.',
-      )
-    }
-  }
-}
-
-export * from './isCurrentUrl'
 export * from './types'
+export * from './isCurrentUrl'
+export * from './buildUrl'

--- a/assets/js/wayfinder/isCurrentUrl.test.ts
+++ b/assets/js/wayfinder/isCurrentUrl.test.ts
@@ -16,7 +16,7 @@ describe('isCurrentUrl', () => {
       isCurrentUrl({
         routePath: '/',
         currentPath: '/venues/1',
-        matchExact: true,
+        exactMatch: true,
       }),
     ).toBe(false)
   })
@@ -75,7 +75,6 @@ describe('isCurrentUrl', () => {
 
   it('falls back to window.location.pathname if currentPath is not provided', () => {
     const originalWindow = global.window
-    // @ts-ignore
     global.window = Object.create(window)
     Object.defineProperty(global.window, 'location', {
       value: { pathname: '/venues/1' },
@@ -93,8 +92,8 @@ describe('isCurrentUrl', () => {
 
   it('returns false if no currentPath and no window object', () => {
     const originalWindow = global.window
-    // @ts-ignore
-    delete global.window
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (global as any).window
 
     expect(
       isCurrentUrl({

--- a/assets/js/wayfinder/isCurrentUrl.ts
+++ b/assets/js/wayfinder/isCurrentUrl.ts
@@ -8,25 +8,28 @@ function getCurrentUrl(currentPath?: string): string | undefined {
 export function isCurrentUrl({
   routePath,
   currentPath,
-  matchExact = false,
+  exactMatch = false,
 }: {
   routePath: string
   currentPath?: string
-  matchExact?: boolean
+  exactMatch?: boolean
 }): boolean {
   const path = getCurrentUrl(currentPath)
 
   if (!path) return false
 
-  const normalize = (url: string) =>
-    url.replace(/\/+$/, '').replace(/\/+/g, '/')
+  const normalize = (url: string) => {
+    // Don't remove trailing slash from root path
+    if (url === '/') return url
+    return url.replace(/\/+$/, '').replace(/\/+/g, '/')
+  }
 
   const normalizedRoutePath = normalize(routePath)
   const normalizedCurrentUrl = normalize(path)
 
   const isTheSame = normalizedCurrentUrl === normalizedRoutePath
 
-  if (matchExact) return isTheSame
+  if (exactMatch) return isTheSame
 
   return isTheSame || normalizedCurrentUrl.startsWith(normalizedRoutePath + '/')
 }

--- a/assets/js/wayfinder/types.ts
+++ b/assets/js/wayfinder/types.ts
@@ -1,14 +1,34 @@
-export type Method = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'head'
+export type Method =
+  | 'get'
+  | 'post'
+  | 'put'
+  | 'delete'
+  | 'patch'
+  | 'head'
+  | 'options'
+
+export type ParamConfig = {
+  name: string
+  required: boolean
+  optional: boolean
+  glob: boolean
+}
 
 export type RouteDefinition<TMethod extends Method | Method[]> = {
   url: string
 } & (TMethod extends Method[] ? { methods: TMethod } : { method: TMethod })
 
+export type ParametersDefinition = Record<string, ParamConfig>
+export type RouteDefinitionWithParameters<TMethod extends Method | Method[]> =
+  RouteDefinition<TMethod> & {
+    parameters: ParametersDefinition
+  }
+
 export type RouteQueryOptions = {
   query?: QueryParams
   mergeQuery?: QueryParams
   currentPath?: string
-  matchExact?: boolean
+  exactMatch?: boolean
 }
 
 export type QueryParams = Record<

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,31 @@
+import pluginPromise from 'eslint-plugin-promise'
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  { ignores: ['dist', 'js/actions/**', 'js/wayfinder/**'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{js,ts,jsx,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      promise: pluginPromise,
+      prettier: eslintPluginPrettierRecommended,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          args: 'all',
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+)

--- a/lib/wayfinder/file_writer.ex
+++ b/lib/wayfinder/file_writer.ex
@@ -38,28 +38,16 @@ defmodule Wayfinder.FileWriter do
   end
 
   @spec build_pathfinder_imports(Processor.controller(), String.t(), Options.t()) :: String.t()
-  defp build_pathfinder_imports(controller, controller_path, opts) do
+  defp build_pathfinder_imports(_controller, controller_path, opts) do
     import_path = build_import_path(controller_path, opts)
 
     imports = [
-      "queryParams",
-      "isCurrentUrl",
+      "buildUrl",
       "type RouteQueryOptions",
       "type RouteDefinition",
+      "type RouteDefinitionWithParameters",
       "type WayfinderUrl"
     ]
-
-    has_optional_param =
-      controller.routes
-      |> Enum.flat_map(& &1.all_params)
-      |> Enum.any?(fn %{optional: opt} -> opt end)
-
-    imports =
-      if has_optional_param do
-        ["validateParameters" | imports]
-      else
-        imports
-      end
 
     "import { #{Enum.join(imports, ", ")} } from '#{import_path}'"
   end

--- a/lib/wayfinder/typescript/build_url_function.ex
+++ b/lib/wayfinder/typescript/build_url_function.ex
@@ -2,179 +2,27 @@ defmodule Wayfinder.Typescript.BuildUrlFunction do
   @moduledoc false
 
   alias Wayfinder.Typescript.{BuildActions, Helpers}
-  alias Wayfinder.Processor.Route
-
-  @url_return """
-    const path = routePath + queryParams(options);
-
-    return {
-      path,
-      isCurrent: isCurrentUrl({
-        routePath,
-        currentPath: options?.currentPath,
-        matchExact: options?.matchExact
-      })
-    }
-  """
 
   @spec build(BuildActions.opts()) :: String.t()
   def build(opts) do
-    all_args = opts.all_arguments
-    optional = Enum.any?(all_args, & &1.optional)
-    args = Helpers.function_args(all_args, opts.url_arguments)
+    args = Helpers.function_args(opts.all_arguments, opts.url_arguments)
     func_opts = Helpers.function_opts()
     safe_name = opts.safe_name
-    parts = build_params(opts, optional, safe_name)
 
-    arguments_helpers =
-      if length(all_args) > 0 do
-        """
-        #{parts.param_parsing}
-        #{parts.array_parsing}
-        #{parts.validate_check}
-        const parsedArgs = { #{parts.parsed_args} }
-
-        """
+    # Only pass args to buildUrl if the function actually has parameters
+    build_url_args =
+      if opts.all_arguments == [] do
+        "definition: #{safe_name}.definition,\n    options"
+      else
+        "definition: #{safe_name}.definition,\n    args,\n    options"
       end
 
     """
     #{safe_name}.url = (#{args} options?: #{func_opts}): WayfinderUrl => {
-      let routePath = #{safe_name}.definition.url
-
-      #{arguments_helpers}
-      routePath = #{build_url_with_replacements(safe_name, all_args)}
-      routePath = routePath.replace(/\\/+$/, '') || '/'
-      #{@url_return}
+      return buildUrl({
+        #{build_url_args}
+      })
     }
     """
-  end
-
-  @spec build_url_with_replacements(String.t(), [String.t()]) :: String.t()
-  defp build_url_with_replacements(name, all_args) do
-    url = "#{name}.definition.url"
-
-    if length(all_args) > 0 do
-      """
-      #{url}
-        #{build_url_replacements(all_args)}
-      """
-    else
-      url
-    end
-  end
-
-  @spec build_url_replacements([Route.param_spec()]) :: String.t()
-  defp build_url_replacements(args) do
-    accessor = "."
-
-    Enum.map_join(args, "\n        ", fn arg ->
-      if arg.glob do
-        ".replace('/*#{arg.name}', Array.isArray(parsedArgs#{accessor}#{arg.name}) ? `/${parsedArgs#{accessor}#{arg.name}.join('/')}` : '')"
-      else
-        ".replace(':#{arg.name}', (parsedArgs#{accessor}#{arg.name} != null ? parsedArgs#{accessor}#{arg.name}.toString() : ''))"
-      end
-    end)
-  end
-
-  defp build_params(opts, optional, safe_name) do
-    args = opts.all_arguments
-
-    %{
-      param_parsing: build_param_parsing(args, safe_name),
-      array_parsing: build_array_parsing(args),
-      validate_check: build_validate_check(args),
-      parsed_args: build_parsed_args(args, optional)
-    }
-  end
-
-  @spec build_param_parsing([Route.param_spec()], String.t()) :: String.t()
-  defp build_param_parsing(args, safe_name) do
-    if Enum.all?(args, & &1.optional) do
-      template_ref = "#{safe_name}.definition.url"
-
-      """
-      if (args == null) {
-        let basePath = #{template_ref};
-        #{Enum.map_join(Enum.reverse(args), "\n", fn param -> "basePath = basePath.replace(/\\/:#{param.name}(\\?)?$/, '');" end)}
-        routePath = basePath || '/'
-        #{@url_return}
-      }
-      """
-    else
-      if length(args) == 1 do
-        """
-        if (args == null) return #{safe_name}.definition.url;
-        if (typeof args === 'string' || typeof args === 'number') {
-          args = { #{hd(args).name}: args }
-        }
-        """
-      else
-        """
-        if (args == null) {
-          #{@url_return}
-        }
-        """
-      end
-    end
-  end
-
-  @spec build_array_parsing([Route.param_spec()]) :: String.t()
-  defp build_array_parsing(args) do
-    cond do
-      length(args) > 1 ->
-        assigns =
-          Enum.with_index(args)
-          |> Enum.map(fn {p, i} -> "#{p.name}: args[#{i}]" end)
-          |> Enum.join(",\n      ")
-
-        """
-        args = args || {};
-        if (Array.isArray(args)) {
-          args = {
-            #{assigns}
-          }
-        }
-        """
-
-      length(args) == 1 ->
-        # Handle single argument case where args could be [value] array
-        param = hd(args)
-
-        """
-        if (Array.isArray(args)) {
-          args = { #{param.name}: args[0] }
-        }
-        """
-
-      true ->
-        ""
-    end
-  end
-
-  @spec build_validate_check([Route.param_spec()]) :: String.t()
-  defp build_validate_check(args) do
-    optional_params = Enum.filter(args, & &1.optional)
-
-    if optional_params != [] do
-      names =
-        optional_params
-        |> Enum.map(&~s|"#{&1.name}"|)
-        |> Enum.join(", ")
-
-      "validateParameters(args, [#{names}])"
-    else
-      ""
-    end
-  end
-
-  @spec build_parsed_args([Route.param_spec()], boolean()) :: String.t()
-  defp build_parsed_args(args, optional) do
-    Enum.map_join(args, ",\n  ", fn arg ->
-      if optional do
-        "#{arg.name}: args?.#{arg.name}"
-      else
-        "#{arg.name}: args.#{arg.name}"
-      end
-    end)
   end
 end

--- a/lib/wayfinder/typescript/helpers.ex
+++ b/lib/wayfinder/typescript/helpers.ex
@@ -112,15 +112,19 @@ defmodule Wayfinder.Typescript.Helpers do
     end
   end
 
-  @spec build_route_definition_type(String.t()) :: String.t()
-  def build_route_definition_type(method) when is_binary(method) do
-    "RouteDefinition<'#{method}'>"
+  @spec build_route_definition_type(String.t() | [String.t()]) :: String.t()
+  @spec build_route_definition_type(String.t() | [String.t()], boolean()) :: String.t()
+  def build_route_definition_type(methods, with_params \\ false)
+
+  def build_route_definition_type(method, with_params) when is_binary(method) do
+    base = if with_params, do: "RouteDefinitionWithParameters", else: "RouteDefinition"
+    "#{base}<'#{method}'>"
   end
 
-  @spec build_route_definition_type([String.t()]) :: String.t()
-  def build_route_definition_type(methods) when is_list(methods) do
+  def build_route_definition_type(methods, with_params) when is_list(methods) do
     method_types = methods |> Enum.map(&"'#{&1}'") |> Enum.join(", ")
-    "RouteDefinition<[#{method_types}]>"
+    base = if with_params, do: "RouteDefinitionWithParameters", else: "RouteDefinition"
+    "#{base}<[#{method_types}]>"
   end
 
   @spec url_args([Route.param_spec()], [Route.param_spec()]) :: String.t()

--- a/package.json
+++ b/package.json
@@ -2,14 +2,26 @@
   "type": "module",
   "description": "Testing the wayfinder generated routes",
   "scripts": {
+    "tc": "tsc --noEmit -p tsconfig.json",
+    "lint": "eslint assets/js/",
+    "prettier": "prettier --write assets/js/**/*.ts",
+    "prettier:check": "prettier --check assets/js/**/*.ts",
     "test": "vitest run",
     "test:verbose": "pnpm run test --reporter verbose",
     "test:watch": "vitest watch"
   },
   "packageManager": "pnpm@9.8.0",
   "devDependencies": {
+    "@eslint/js": "^9.13.0",
     "@types/node": "^22.7.5",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-promise": "^7.1.0",
+    "globals": "^16.2.0",
     "happy-dom": "^15.11.7",
+    "prettier": "3.3.3",
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.11.0",
     "vitest": "^3.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,36 @@ importers:
 
   .:
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.13.0
+        version: 9.29.0
       '@types/node':
         specifier: ^22.7.5
         version: 22.15.2
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@9.29.0)
+      eslint-plugin-prettier:
+        specifier: ^5.2.1
+        version: 5.4.1(eslint-config-prettier@9.1.0(eslint@9.29.0))(eslint@9.29.0)(prettier@3.3.3)
+      eslint-plugin-promise:
+        specifier: ^7.1.0
+        version: 7.2.1(eslint@9.29.0)
+      globals:
+        specifier: ^16.2.0
+        version: 16.2.0
       happy-dom:
         specifier: ^15.11.7
         version: 15.11.7
+      prettier:
+        specifier: 3.3.3
+        version: 3.3.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.8.3
+      typescript-eslint:
+        specifier: ^8.11.0
+        version: 8.34.0(eslint@9.29.0)(typescript@5.8.3)
       vitest:
         specifier: ^3.1.2
         version: 3.1.2(@types/node@22.15.2)(happy-dom@15.11.7)
@@ -170,8 +194,86 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.7.0':
+    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.20.1':
+    resolution: {integrity: sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.2.3':
+    resolution: {integrity: sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.14.0':
+    resolution: {integrity: sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.15.0':
+    resolution: {integrity: sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.29.0':
+    resolution: {integrity: sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.6':
+    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.3.2':
+    resolution: {integrity: sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.6':
+    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.3.1':
+    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
+    engines: {node: '>=18.18'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@pkgr/core@0.2.7':
+    resolution: {integrity: sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@rollup/rollup-android-arm-eabi@4.40.0':
     resolution: {integrity: sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==}
@@ -276,8 +378,70 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node@22.15.2':
     resolution: {integrity: sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==}
+
+  '@typescript-eslint/eslint-plugin@8.34.0':
+    resolution: {integrity: sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.34.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/parser@8.34.0':
+    resolution: {integrity: sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/project-service@8.34.0':
+    resolution: {integrity: sha512-iEgDALRf970/B2YExmtPMPF54NenZUf4xpL3wsCRx/lgjz6ul/l13R81ozP/ZNuXfnLCS+oPmG7JIxfdNYKELw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/scope-manager@8.34.0':
+    resolution: {integrity: sha512-9Ac0X8WiLykl0aj1oYQNcLZjHgBojT6cW68yAgZ19letYu+Hxd0rE0veI1XznSSst1X5lwnxhPbVdwjDRIomRw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.34.0':
+    resolution: {integrity: sha512-+W9VYHKFIzA5cBeooqQxqNriAP0QeQ7xTiDuIOr71hzgffm3EL2hxwWBIIj4GuofIbKxGNarpKqIq6Q6YrShOA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/type-utils@8.34.0':
+    resolution: {integrity: sha512-n7zSmOcUVhcRYC75W2pnPpbO1iwhJY3NLoHEtbJwJSNlVAZuwqu05zY3f3s2SDWWDSo9FdN5szqc73DCtDObAg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/types@8.34.0':
+    resolution: {integrity: sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.34.0':
+    resolution: {integrity: sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/utils@8.34.0':
+    resolution: {integrity: sha512-8L4tWatGchV9A1cKbjaavS6mwYwp39jql8xUmIIKJdm+qiaeHy5KMKlBrf30akXAWBzn2SqKsNOtSENWUwg7XQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/visitor-keys@8.34.0':
+    resolution: {integrity: sha512-qHV7pW7E85A0x6qyrFn+O+q1k1p3tQCsqIZ1KZ5ESLXY57aTvUd3/a4rdPTeXisvhXn2VQG0VSKUqs8KHF2zcA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/expect@3.1.2':
     resolution: {integrity: sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==}
@@ -308,21 +472,76 @@ packages:
   '@vitest/utils@3.1.2':
     resolution: {integrity: sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -337,6 +556,9 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -349,12 +571,103 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-config-prettier@9.1.0:
+    resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
+  eslint-plugin-prettier@5.4.1:
+    resolution: {integrity: sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
+
+  eslint-plugin-promise@7.2.1:
+    resolution: {integrity: sha512-SWKjd+EuvWkYaS+uN2csvj0KoP43YTu7+phKQ5v+xw6+A0gutVX2yqCeCkC3uLCJFiPfR2dD8Es5L7yUsmvEaA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.29.0:
+    resolution: {integrity: sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   expect-type@1.2.1:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
   fdir@6.4.4:
     resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
@@ -364,20 +677,135 @@ packages:
       picomatch:
         optional: true
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.2.0:
+    resolution: {integrity: sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==}
+    engines: {node: '>=18'}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
   happy-dom@15.11.7:
     resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
     engines: {node: '>=18.0.0'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -386,6 +814,33 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -397,6 +852,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
@@ -405,10 +864,54 @@ packages:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier-linter-helpers@1.0.0:
+    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+    engines: {node: '>=6.0.0'}
+
+  prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rollup@4.40.0:
     resolution: {integrity: sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -422,6 +925,18 @@ packages:
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  synckit@0.11.8:
+    resolution: {integrity: sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -445,8 +960,37 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-api-utils@2.1.0:
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.34.0:
+    resolution: {integrity: sha512-MRpfN7uYjTrTGigFCt8sRyNqJFhjN0WwZecldaqhWm+wy0gaRt8Edb/3cuUy0zdq2opJWT6iXINKAtewnDOltQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   vite-node@3.1.2:
     resolution: {integrity: sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==}
@@ -529,10 +1073,23 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
 snapshots:
 
@@ -611,7 +1168,82 @@ snapshots:
   '@esbuild/win32-x64@0.25.3':
     optional: true
 
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0)':
+    dependencies:
+      eslint: 9.29.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/config-array@0.20.1':
+    dependencies:
+      '@eslint/object-schema': 2.1.6
+      debug: 4.4.0
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.2.3': {}
+
+  '@eslint/core@0.14.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@0.15.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.0
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.29.0': {}
+
+  '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/plugin-kit@0.3.2':
+    dependencies:
+      '@eslint/core': 0.15.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.6':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.3.1
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.3.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+
+  '@pkgr/core@0.2.7': {}
 
   '@rollup/rollup-android-arm-eabi@4.40.0':
     optional: true
@@ -675,9 +1307,103 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/node@22.15.2':
     dependencies:
       undici-types: 6.21.0
+
+  '@typescript-eslint/eslint-plugin@8.34.0(@typescript-eslint/parser@8.34.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.34.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.34.0
+      '@typescript-eslint/type-utils': 8.34.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.34.0
+      eslint: 9.29.0
+      graphemer: 1.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.34.0(eslint@9.29.0)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.34.0
+      '@typescript-eslint/types': 8.34.0
+      '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.34.0
+      debug: 4.4.0
+      eslint: 9.29.0
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.34.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.34.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.34.0
+      debug: 4.4.0
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.34.0':
+    dependencies:
+      '@typescript-eslint/types': 8.34.0
+      '@typescript-eslint/visitor-keys': 8.34.0
+
+  '@typescript-eslint/tsconfig-utils@8.34.0(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
+  '@typescript-eslint/type-utils@8.34.0(eslint@9.29.0)(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.29.0)(typescript@5.8.3)
+      debug: 4.4.0
+      eslint: 9.29.0
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.34.0': {}
+
+  '@typescript-eslint/typescript-estree@8.34.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.34.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.34.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.34.0
+      '@typescript-eslint/visitor-keys': 8.34.0
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.34.0(eslint@9.29.0)(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@typescript-eslint/scope-manager': 8.34.0
+      '@typescript-eslint/types': 8.34.0
+      '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.8.3)
+      eslint: 9.29.0
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.34.0':
+    dependencies:
+      '@typescript-eslint/types': 8.34.0
+      eslint-visitor-keys: 4.2.1
 
   '@vitest/expect@3.1.2':
     dependencies:
@@ -719,9 +1445,45 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
   assertion-error@2.0.1: {}
 
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   cac@6.7.14: {}
+
+  callsites@3.1.0: {}
 
   chai@5.2.0:
     dependencies:
@@ -731,13 +1493,34 @@ snapshots:
       loupe: 3.1.3
       pathval: 2.0.0
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   check-error@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   debug@4.4.0:
     dependencies:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
+
+  deep-is@0.1.4: {}
 
   entities@4.5.0: {}
 
@@ -771,18 +1554,159 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.3
       '@esbuild/win32-x64': 0.25.3
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-config-prettier@9.1.0(eslint@9.29.0):
+    dependencies:
+      eslint: 9.29.0
+
+  eslint-plugin-prettier@5.4.1(eslint-config-prettier@9.1.0(eslint@9.29.0))(eslint@9.29.0)(prettier@3.3.3):
+    dependencies:
+      eslint: 9.29.0
+      prettier: 3.3.3
+      prettier-linter-helpers: 1.0.0
+      synckit: 0.11.8
+    optionalDependencies:
+      eslint-config-prettier: 9.1.0(eslint@9.29.0)
+
+  eslint-plugin-promise@7.2.1(eslint@9.29.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      eslint: 9.29.0
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.29.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.20.1
+      '@eslint/config-helpers': 0.2.3
+      '@eslint/core': 0.14.0
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.29.0
+      '@eslint/plugin-kit': 0.3.2
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.7
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.7
 
+  esutils@2.0.3: {}
+
   expect-type@1.2.1: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-diff@1.3.0: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
 
   fdir@6.4.4(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
+  flatted@3.3.3: {}
+
   fsevents@2.3.3:
     optional: true
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  globals@16.2.0: {}
+
+  graphemer@1.4.0: {}
 
   happy-dom@15.11.7:
     dependencies:
@@ -790,21 +1714,113 @@ snapshots:
       webidl-conversions: 7.0.0
       whatwg-mimetype: 3.0.0
 
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
   loupe@3.1.3: {}
 
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  natural-compare@1.4.0: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
 
   pathe@2.0.3: {}
 
   pathval@2.0.0: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
 
@@ -813,6 +1829,22 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  prettier-linter-helpers@1.0.0:
+    dependencies:
+      fast-diff: 1.3.0
+
+  prettier@3.3.3: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
 
   rollup@4.40.0:
     dependencies:
@@ -840,6 +1872,18 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.40.0
       fsevents: 2.3.3
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  semver@7.7.2: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -847,6 +1891,16 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.9.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  synckit@0.11.8:
+    dependencies:
+      '@pkgr/core': 0.2.7
 
   tinybench@2.9.0: {}
 
@@ -863,7 +1917,35 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-api-utils@2.1.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.34.0(eslint@9.29.0)(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.34.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.29.0)(typescript@5.8.3)
+      eslint: 9.29.0
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@5.8.3: {}
+
   undici-types@6.21.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   vite-node@3.1.2(@types/node@22.15.2):
     dependencies:
@@ -942,7 +2024,15 @@ snapshots:
 
   whatwg-mimetype@3.0.0: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}

--- a/test/js/support/build.ts
+++ b/test/js/support/build.ts
@@ -10,7 +10,7 @@ export async function setup(): Promise<void> {
       stdio: 'inherit',
       env: { ...process.env, MIX_ENV: 'test' }
     })
-  } catch (error) {
+  } catch {
     process.exit(1)
   }
 }

--- a/test/js/tests/OtherVerbsController.test.ts
+++ b/test/js/tests/OtherVerbsController.test.ts
@@ -14,6 +14,7 @@ describe('headAction', () => {
   it('definition', () => {
     expect(headAction.definition).toEqual({
       url: '/other-verbs/head',
+      parameters: {},
       methods: ['head'],
     })
   })
@@ -27,6 +28,7 @@ describe('optionsAction', () => {
   it('definition', () => {
     expect(optionsAction.definition).toEqual({
       url: '/other-verbs/options',
+      parameters: {},
       methods: ['options'],
     })
   })
@@ -40,6 +42,7 @@ describe('matchAction', () => {
   it('definition', () => {
     expect(matchAction.definition).toEqual({
       url: '/other-verbs/match',
+      parameters: {},
       methods: ['get', 'patch', 'post', 'put'],
     })
   })
@@ -47,13 +50,18 @@ describe('matchAction', () => {
 
 describe('matchWithParams', () => {
   it('url', () => {
-    expect(matchWithParams.url({ id: '123' }).path).toBe('/other-verbs/match/123')
+    expect(matchWithParams.url({ id: '123' }).path).toBe(
+      '/other-verbs/match/123',
+    )
     expect(matchWithParams.url('456').path).toBe('/other-verbs/match/456')
   })
 
   it('definition', () => {
     expect(matchWithParams.definition).toEqual({
       url: '/other-verbs/match/:id',
+      parameters: {
+        id: { name: 'id', required: true, optional: false, glob: false },
+      },
       methods: ['get', 'post'],
     })
   })
@@ -83,14 +91,10 @@ describe('matchWithParams', () => {
   })
 
   it('can use post method with an object string ', () => {
-    expect(matchWithParams.post({ id: '20' }).url).toBe(
-      '/other-verbs/match/20',
-    )
+    expect(matchWithParams.post({ id: '20' }).url).toBe('/other-verbs/match/20')
   })
 
   it('can use post method with an object number ', () => {
-    expect(matchWithParams.post({ id: 20 }).url).toBe(
-      '/other-verbs/match/20',
-    )
+    expect(matchWithParams.post({ id: 20 }).url).toBe('/other-verbs/match/20')
   })
 })

--- a/test/js/tests/PageController.test.ts
+++ b/test/js/tests/PageController.test.ts
@@ -13,7 +13,7 @@ it('match exact url', () => {
   expect(
     home.url({
       currentPath: '/events',
-      matchExact: true,
+      exactMatch: true,
     }).isCurrent,
   ).toBe(false)
 })

--- a/test/js/tests/ResourcesController.test.ts
+++ b/test/js/tests/ResourcesController.test.ts
@@ -19,6 +19,7 @@ describe('ResourcesController RESTful routes', () => {
     it('has correct definition', () => {
       expect(index.definition).toEqual({
         url: '/resources',
+        parameters: {},
         methods: ['get'],
       })
     })
@@ -40,6 +41,9 @@ describe('ResourcesController RESTful routes', () => {
     it('has correct definition', () => {
       expect(show.definition).toEqual({
         url: '/resources/:id',
+        parameters: {
+          id: { name: 'id', required: true, optional: false, glob: false },
+        },
         methods: ['get'],
       })
     })
@@ -66,6 +70,7 @@ describe('ResourcesController RESTful routes', () => {
     it('has correct definition', () => {
       expect(newMethod.definition).toEqual({
         url: '/resources/new',
+        parameters: {},
         methods: ['get'],
       })
     })
@@ -85,6 +90,7 @@ describe('ResourcesController RESTful routes', () => {
     it('has correct definition', () => {
       expect(create.definition).toEqual({
         url: '/resources',
+        parameters: {},
         methods: ['post'],
       })
     })
@@ -106,6 +112,9 @@ describe('ResourcesController RESTful routes', () => {
     it('has correct definition', () => {
       expect(edit.definition).toEqual({
         url: '/resources/:id/edit',
+        parameters: {
+          id: { name: 'id', required: true, optional: false, glob: false },
+        },
         methods: ['get'],
       })
     })
@@ -114,6 +123,11 @@ describe('ResourcesController RESTful routes', () => {
       expect(edit.get({ id: '123' }).method).toBe('get')
       expect(edit.get({ id: '123' }).url).toBe('/resources/123/edit')
       expect(edit.get('456').url).toBe('/resources/456/edit')
+    })
+
+    it('throws an error when not passing the id', () => {
+      // @ts-expect-error - Testing error handling
+      expect(() => edit.url().path).toThrow()
     })
   })
 
@@ -128,6 +142,9 @@ describe('ResourcesController RESTful routes', () => {
     it('has correct definition', () => {
       expect(update.definition).toEqual({
         methods: ['patch', 'put'],
+        parameters: {
+          id: { name: 'id', required: true, optional: false, glob: false },
+        },
         url: '/resources/:id',
       })
     })
@@ -156,6 +173,9 @@ describe('ResourcesController RESTful routes', () => {
     it('has correct definition', () => {
       expect(deleteMethod.definition).toEqual({
         url: '/resources/:id',
+        parameters: {
+          id: { name: 'id', required: true, optional: false, glob: false },
+        },
         methods: ['delete'],
       })
     })

--- a/test/js/tests/TwoRoutesSameActionController.test.ts
+++ b/test/js/tests/TwoRoutesSameActionController.test.ts
@@ -17,6 +17,7 @@ describe('TwoRoutesSameActionController', () => {
     it('has correct definition with RouteDefinition type', () => {
       expect(same.definition).toEqual({
         methods: ['get'],
+        parameters: {},
         url: '/two-routes-one-action-1',
       })
     })
@@ -50,6 +51,7 @@ describe('TwoRoutesSameActionController', () => {
     it('has correct definition with RouteDefinition type', () => {
       expect(same2.definition).toEqual({
         methods: ['get'],
+        parameters: {},
         url: '/two-routes-one-action-2',
       })
     })
@@ -93,6 +95,7 @@ describe('TwoRoutesSameActionController', () => {
     it("definitions satisfy RouteDefinition<['get']>", () => {
       expect(Array.isArray(same.definition.methods)).toBe(true)
       expect(Array.isArray(same2.definition.methods)).toBe(true)
+      expect(same.definition.parameters).toEqual({})
       expect(same.definition.methods).toContain('get')
       expect(same2.definition.methods).toContain('get')
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,15 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "types": ["vite", "vitest/globals"],
-    "baseUrl": "."
+    "baseUrl": ".",
+    "skipLibCheck": true,
+    "types": ["vitest/globals", "node"]
   },
   "include": [
-    "vite.config.ts",
+    "assets/js/**/*",
     "test/js/tests/**/*",
+    "**/*.test.ts",
     "tests/js/support/build.ts"
-  ]
+  ],
+  "exclude": ["node_modules"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+// @ts-check
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({


### PR DESCRIPTION
# What?
I copy initially the approach I saw in Laravel Wayfinder of generating all JS logic with the backend language. In this case Elixir. But I find really hard to follow so I made a JS function where I can cover fully with unit tests.

## TODO
- [x] Fix linters and shit
- [x] Add unit tests to `buildUrl`
- [x] All previous integration tests should pass

## Next

- [x] [Implement CI](https://github.com/andresgutgon/phoenix-wayfinder/issues/6)
- [x] Write the README with all the details about dev, prod, how to use it, gitignore,...
- [x] Release 
- [x] 📣 Tell people!

