### PR TITLE
Ignore forward routes for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y inotify-tools
 
       - name: Set up Elixir and OTP
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@v1.18.2
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
 
@@ -45,14 +45,14 @@ jobs:
         run: npm install -g pnpm
 
       - name: Restore dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: deps-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: deps-${{ runner.os }}-
 
       - name: 💾 Cache pnpm store
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('assets/pnpm-lock.yaml') }}
@@ -69,7 +69,7 @@ jobs:
         run: mkdir -p priv/plts
 
       - name: Cache PLT files
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: priv/plts
           key: plt-${{ runner.os }}-${{ hashFiles('mix.lock') }}

--- a/lib/wayfinder/processor.ex
+++ b/lib/wayfinder/processor.ex
@@ -69,7 +69,13 @@ defmodule Wayfinder.Processor do
 
   defp drop_app_namespace([_app | rest]), do: rest
 
-  # Possible to have routes without controller. Skip them.
-  defp valid_wayfinder_route?(%{plug: controller}) when is_atom(controller), do: true
+  # Valid routes must have:
+  # - plug (controller) as an atom
+  # - plug_opts (action) as an atom
+  # This filters out forward routes where plug_opts is a keyword list
+  defp valid_wayfinder_route?(%{plug: controller, plug_opts: action})
+       when is_atom(controller) and is_atom(action),
+       do: true
+
   defp valid_wayfinder_route?(_), do: false
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -1,5 +1,13 @@
+defmodule TestApp.FakeStrategyRouter do
+  @moduledoc """
+  A fake router module to simulate AshAuthentication.Phoenix.StrategyRouter
+  for testing forward route filtering.
+  """
+  def init(opts), do: opts
+  def call(conn, _opts), do: conn
+end
 
-defmodule TestRouter do
+defmodule TestApp.TestRouter do
   use Phoenix.Router
 
   @moduledoc """
@@ -8,6 +16,24 @@ defmodule TestRouter do
   without depending on the workbench or external dependencies.
   """
 
-  get "/test", TestController, :index
-  get "/test/:id", TestController, :show
+  get("/test", TestApp.TestController, :index)
+  get("/test/:id", TestApp.TestController, :show)
+end
+
+defmodule TestApp.TestRouterWithForward do
+  use Phoenix.Router
+
+  @moduledoc """
+  A test router that includes a forward route to test filtering.
+  This simulates routers that use forward for authentication (like AshAuthentication).
+  """
+
+  get("/posts", TestApp.TestController, :index)
+  get("/posts/:id", TestApp.TestController, :show)
+
+  forward("/auth", TestApp.FakeStrategyRouter,
+    path: "/auth",
+    as: :auth,
+    only: [:github, :google]
+  )
 end

--- a/test/support/test_controller.ex
+++ b/test/support/test_controller.ex
@@ -1,4 +1,4 @@
-defmodule TestController do
+defmodule TestApp.TestController do
   import Plug.Conn
 
   @moduledoc """

--- a/test/wayfinder/processor_test.exs
+++ b/test/wayfinder/processor_test.exs
@@ -1,0 +1,33 @@
+defmodule Wayfinder.ProcessorTest do
+  use ExUnit.Case, async: true
+
+  alias Wayfinder.Processor
+
+  describe "call/1" do
+    test "filters out forward routes with non-atom plug_opts" do
+      {:ok, controllers} = Processor.call(TestApp.TestRouter)
+
+      assert length(controllers) == 1
+      assert hd(controllers).module == TestApp.TestController
+    end
+  end
+
+  describe "valid route filtering" do
+    test "accepts routes where plug and plug_opts are both atoms" do
+      {:ok, controllers} = Processor.call(TestApp.TestRouterWithForward)
+
+      controller_modules = Enum.map(controllers, & &1.module)
+
+      assert TestApp.TestController in controller_modules
+      refute TestApp.FakeStrategyRouter in controller_modules
+    end
+
+    test "filters out forward routes with keyword list plug_opts" do
+      {:ok, controllers} = Processor.call(TestApp.TestRouterWithForward)
+
+      all_routes = Enum.flat_map(controllers, & &1.routes)
+
+      refute Enum.any?(all_routes, fn route -> route.path == "/auth" end)
+    end
+  end
+end

--- a/test/wayfinder/routes_watcher_test.exs
+++ b/test/wayfinder/routes_watcher_test.exs
@@ -8,7 +8,7 @@ defmodule Wayfinder.RoutesWatcherTest do
     def generate(_router, _otp_app), do: :ok
   end
 
-  @router_module TestRouter
+  @router_module TestApp.TestRouter
 
   setup do
     if Process.whereis(RoutesWatcher) do


### PR DESCRIPTION
# What?
While using Ash Authentication routes, I saw they use Phoenix feature [forward](https://hexdocs.pm/phoenix/Phoenix.Router.html#forward/4) to forward `/auth` routes from `AuthAuthentication.Phoenix.StrategyRouter` to the controller defined by the user. But the generated routes by Ash auth are too dynamic and complex for me to invest time in this use case. I'm just doing a fix to avoid failing